### PR TITLE
♿ Fix - Homepage accessibility changes

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -13,7 +12,7 @@
     <title>Szkolenie MUMO</title>
   </head>
   <body>
-    <div id="root"></div>
+    <div id="root" role="presentation"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/components/features/home/about/AboutSection.tsx
+++ b/src/components/features/home/about/AboutSection.tsx
@@ -57,7 +57,6 @@ const AboutSection = () => {
         <div className="about__block">
           <div
             className="about__image-container about__image-second"
-            role="presentation"
           >
             <img
               className="about__image"
@@ -102,7 +101,6 @@ const AboutSection = () => {
           </div>
           <div
             className="about__image-container about__image-third"
-            role="presentation"
           >
             <img
               className="about__image"

--- a/src/components/features/home/about/AboutSection.tsx
+++ b/src/components/features/home/about/AboutSection.tsx
@@ -55,7 +55,10 @@ const AboutSection = () => {
           </div>
         </div>
         <div className="about__block">
-          <div className="about__image-container about__image-second">
+          <div
+            className="about__image-container about__image-second"
+            role="presentation"
+          >
             <img
               className="about__image"
               src={ABOUT_IMAGES[1].src}
@@ -97,7 +100,10 @@ const AboutSection = () => {
               </p>
             </Fade>
           </div>
-          <div className="about__image-container about__image-third">
+          <div
+            className="about__image-container about__image-third"
+            role="presentation"
+          >
             <img
               className="about__image"
               src={ABOUT_IMAGES[2].src}

--- a/src/components/features/home/about/about-circles/AboutCircles.tsx
+++ b/src/components/features/home/about/about-circles/AboutCircles.tsx
@@ -1,219 +1,101 @@
+import HollowCircle from '../../../../shared/shapes/HollowCircle'
+
+const CIRCLE_COLOR: string = '#8dd9cc'
+const CIRCLE_CLASS: string = 'about__image-circle'
+
 export const CirclesFirst = () => {
-    return(
-        <>
-        <svg
-                xmlns="http://www.w3.org/2000/svg"
-                width="42"
-                height="43"
-                viewBox="0 0 42 43"
-                fill="none"
-                className="about__image-circle"
-              >
-                <ellipse
-                  cx="21"
-                  cy="21.5"
-                  rx="21"
-                  ry="21.5"
-                  fill="#B1E8DF"
-                  fillOpacity="0.66"
-                />
-                <ellipse
-                  cx="12.4628"
-                  cy="12.7492"
-                  rx="12.4628"
-                  ry="12.7492"
-                  transform="matrix(0.990965 0.134118 -0.128056 0.991767 10.3838 7.28809)"
-                  fill="white"
-                />
-              </svg>
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                width="75"
-                height="74"
-                viewBox="0 0 75 74"
-                fill="none"
-                className="about__image-circle"
-              >
-                <ellipse
-                  cx="37.5"
-                  cy="37"
-                  rx="37.5"
-                  ry="37"
-                  fill="#B1E8DF"
-                  fillOpacity="0.92"
-                />
-                <ellipse
-                  cx="22.2407"
-                  cy="21.9543"
-                  rx="22.2407"
-                  ry="21.9543"
-                  transform="matrix(0.991601 0.129335 -0.132793 0.991144 18.5427 12.542)"
-                  fill="white"
-                />
-              </svg>
-        </>      
-    )
+  return (
+    <>
+      <HollowCircle
+        className={CIRCLE_CLASS}
+        svgSize={43}
+        cx={20}
+        cy={20}
+        radius={15}
+        strokeWidth={8}
+        color={CIRCLE_COLOR}
+        opacity={0.8}
+      />
+      <HollowCircle
+        className={CIRCLE_CLASS}
+        svgSize={75}
+        cx={37}
+        cy={37}
+        radius={29}
+        strokeWidth={15}
+        color={CIRCLE_COLOR}
+      />
+    </>
+  )
 }
 
 export const CirclesSecond = () => {
-    return(
-        <>
-                    <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="42"
-              height="43"
-              viewBox="0 0 42 43"
-              fill="none"
-              className="about__image-circle"
-            >
-              <ellipse
-                cx="21"
-                cy="21.5"
-                rx="21"
-                ry="21.5"
-                fill="#B1E8DF"
-                fillOpacity="0.66"
-              />
-              <ellipse
-                cx="12.4628"
-                cy="12.7492"
-                rx="12.4628"
-                ry="12.7492"
-                transform="matrix(0.990965 0.134118 -0.128056 0.991767 10.3838 7.28809)"
-                fill="white"
-              />
-            </svg>
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="42"
-              height="43"
-              viewBox="0 0 42 43"
-              fill="none"
-              className="about__image-circle"
-            >
-              <ellipse
-                cx="21"
-                cy="21.5"
-                rx="21"
-                ry="21.5"
-                fill="#B1E8DF"
-                fillOpacity="0.66"
-              />
-              <ellipse
-                cx="12.4628"
-                cy="12.7492"
-                rx="12.4628"
-                ry="12.7492"
-                transform="matrix(0.990965 0.134118 -0.128056 0.991767 10.3838 7.28809)"
-                fill="white"
-              />
-            </svg>
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="75"
-              height="74"
-              viewBox="0 0 75 74"
-              fill="none"
-              className="about__image-circle"
-            >
-              <ellipse
-                cx="37.5"
-                cy="37"
-                rx="37.5"
-                ry="37"
-                fill="#B1E8DF"
-                fillOpacity="0.92"
-              />
-              <ellipse
-                cx="22.2407"
-                cy="21.9543"
-                rx="22.2407"
-                ry="21.9543"
-                transform="matrix(0.991601 0.129335 -0.132793 0.991144 18.5425 12.5425)"
-                fill="white"
-              />
-            </svg>
-        </>
-    )
+  return (
+    <>
+      <HollowCircle
+        className={CIRCLE_CLASS}
+        svgSize={45}
+        cx={21}
+        cy={21}
+        radius={17}
+        strokeWidth={9}
+        color={CIRCLE_COLOR}
+        opacity={0.7}
+      />
+      <HollowCircle
+        className={CIRCLE_CLASS}
+        svgSize={0}
+        cx={21}
+        cy={21}
+        radius={17}
+        strokeWidth={9}
+        color={CIRCLE_COLOR}
+        opacity={0.6}
+      />
+      <HollowCircle
+        className={CIRCLE_CLASS}
+        svgSize={0}
+        cx={37}
+        cy={37}
+        radius={29}
+        strokeWidth={15}
+        color={CIRCLE_COLOR}
+      />
+    </>
+  )
 }
 export const CirclesThird = () => {
-    return(
-        <>
-                    <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="31"
-              height="32"
-              viewBox="0 0 31 32"
-              fill="none"
-              className="about__image-circle"
-            >
-              <ellipse
-                cx="15.5779"
-                cy="15.9112"
-                rx="14.9333"
-                ry="15.2889"
-                fill="#B1E8DF"
-                fillOpacity="0.66"
-              />
-              <ellipse
-                cx="8.86242"
-                cy="9.0661"
-                rx="8.86242"
-                ry="9.0661"
-                transform="matrix(0.990965 0.134118 -0.128056 0.991767 8.02832 5.80493)"
-                fill="white"
-              />
-            </svg>
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="55"
-              height="54"
-              viewBox="0 0 55 54"
-              fill="none"
-              className="about__image-circle"
-            >
-              <ellipse
-                cx="27.3781"
-                cy="26.867"
-                rx="26.6667"
-                ry="26.3111"
-                fill="#B1E8DF"
-                fillOpacity="0.92"
-              />
-              <ellipse
-                cx="15.8156"
-                cy="15.6119"
-                rx="15.8156"
-                ry="15.6119"
-                transform="matrix(0.991601 0.129335 -0.132793 0.991144 13.897 9.47498)"
-                fill="white"
-              />
-            </svg>
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="31"
-              height="32"
-              viewBox="0 0 31 32"
-              fill="none"
-              className="about__image-circle"
-            >
-              <ellipse
-                cx="15.4226"
-                cy="16.0225"
-                rx="14.9333"
-                ry="15.2889"
-                fill="#B1E8DF"
-                fillOpacity="0.66"
-              />
-              <ellipse
-                cx="8.86242"
-                cy="9.0661"
-                rx="8.86242"
-                ry="9.0661"
-                transform="matrix(0.990965 0.134118 -0.128056 0.991767 7.87305 5.91626)"
-                fill="white"
-              />
-            </svg>
-        </>
-    )
+  return (
+    <>
+      <HollowCircle
+        className={CIRCLE_CLASS}
+        svgSize={45}
+        cx={22}
+        cy={22}
+        radius={17}
+        strokeWidth={9}
+        color={CIRCLE_COLOR}
+        opacity={0.7}
+      />
+      <HollowCircle
+        className={CIRCLE_CLASS}
+        svgSize={0}
+        cx={24}
+        cy={24}
+        radius={19}
+        strokeWidth={10}
+        color={CIRCLE_COLOR}
+        opacity={0.8}
+      />
+      <HollowCircle
+        className={CIRCLE_CLASS}
+        svgSize={0}
+        cx={37}
+        cy={37}
+        radius={29}
+        strokeWidth={15}
+        color={CIRCLE_COLOR}
+      />
+    </>
+  )
 }

--- a/src/components/features/home/about/about-section.scss
+++ b/src/components/features/home/about/about-section.scss
@@ -1,3 +1,9 @@
+@use 'sass:map';
+@import '../../../../styles/helpers/variables';
+
+$header-color: map-get($colors, header-blue);
+$header-underline-color: rgb(156, 224, 214);
+
 .about__container {
   display: flex;
   flex-direction: column;
@@ -21,9 +27,9 @@
   font-size: 3rem;
   padding-left: 0.5em;
   text-transform: uppercase;
-  color: #46b8a7;
+  color: $header-color;
   width: fit-content;
-  text-shadow: 0px 2px 3px rgba(0, 0, 0, 0.5);
+  text-shadow: 0px 2px 2px rgba(0, 0, 0, 0.5);
   -webkit-background-clip: text;
   -moz-background-clip: text;
   background-clip: text;
@@ -31,7 +37,7 @@
 .about__content-header:after {
   content: '';
   float: left;
-  background: rgba(183, 234, 226, 1);
+  background: $header-underline-color;
   width: 110%;
   height: 0.4rem;
   left: -5%;
@@ -48,18 +54,19 @@
   font-size: 1.5rem;
   font-style: normal;
   font-weight: 300;
-  line-height: 40px;
+  line-height: 1.9em;
   text-align: left;
 }
 .about__image-container {
   width: 45%;
   display: flex;
   justify-content: center;
-  margin-top: 25px;
-  margin-bottom: 25px;
+  margin-top: 2.5em;
+  margin-bottom: 2.5em;
+  
 }
 .about__image-circles {
-  width: 0;
+  position: absolute;
 }
 .about__image {
   max-width: 400px;
@@ -75,14 +82,14 @@
     &:first-of-type {
       min-width: 42px;
       min-height: 43px;
-      top: 0px;
-      left: -45px;
+      top: -30px;
+      left: 220px;
     }
     &:nth-of-type(2) {
       min-width: 75px;
       min-height: 74px;
-      top: 10px;
-      left: 0px;
+      top: 50px;
+      left: 200px;
     }
   }
 }
@@ -92,21 +99,20 @@
     &:first-of-type {
       min-width: 42px;
       min-height: 43px;
-      top: 20px;
-      left: -395px;
+      top: -20px;
+      left: -120px;
     }
     &:nth-of-type(2) {
       min-width: 42px;
       min-height: 43px;
-      top: 285px;
-      left: -60px;
+      top: 330px;
+      left: 165px;
     }
     &:nth-of-type(3) {
       min-width: 75px;
       min-height: 74px;
-      top: 130px;
-      left: -50px;
-      z-index: -1;
+      top: 300px;
+      left: 170px;
     }
   }
 }
@@ -117,20 +123,20 @@
     &:first-of-type {
       min-width: 42px;
       min-height: 43px;
-      top: -10px;
-      left: -340px;
+      top: -50px;
+      left: -60px;
     }
     &:nth-of-type(2) {
       min-width: 55px;
       min-height: 54px;
-      top: 280px;
-      left: -35px;
+      top: 380px;
+      left: 130px;
     }
     &:nth-of-type(3) {
       min-width: 75px;
       min-height: 74px;
-      top: -50px;
-      left: -420px;
+      top: 40px;
+      left: -220px;
       z-index: -1;
     }
   }
@@ -163,24 +169,37 @@
   }
 }
 @media screen and (max-width: 580px) {
+  
   .about__image {
     max-width: 300px;
   }
-
+  .about__image-first{
+    .about__image-circle{
+      &:first-of-type{
+        top:-40px;
+        left: 150px;
+      }
+      &:nth-of-type(2){
+        top: 50px;
+        left: 110px;
+        z-index: -1;
+      }
+    }
+  }
   .about__image-second {
     .about__image-circle {
       position: relative;
       &:first-of-type {
-        top: 10px;
-        left: -305px;
+        top: -50px;
+        left: -80px;
       }
       &:nth-of-type(2) {
-        top: 190px;
-        left: -35px;
+        top: 250px;
+        left: 110px;
       }
       &:nth-of-type(3) {
-        top: 50px;
-        left: -50px;
+        top: 190px;
+        left: 80px;
         z-index: -1;
       }
     }
@@ -190,16 +209,16 @@
     .about__image-circle {
       position: relative;
       &:first-of-type {
-        top: -10px;
-        left: -280px;
-      }
-      &:nth-of-type(2) {
-        top: 190px;
+        top: -50px;
         left: -35px;
       }
+      &:nth-of-type(2) {
+        top: 250px;
+        left: 140px;
+      }
       &:nth-of-type(3) {
-        top: -50px;
-        left: -330px;
+        top: 30px;
+        left: -180px;
         z-index: -1;
       }
     }

--- a/src/components/features/home/offer/offer-card/offer-card.scss
+++ b/src/components/features/home/offer/offer-card/offer-card.scss
@@ -5,20 +5,24 @@ $content-font-color: map-get($colors, light-gray);
 $price-content-font-color: map-get($colors, dark-gray);
 
 .offer-card {
-  width: 310px;
+  width: 340px;
   display: flex;
   flex-direction: column;
   text-align: center;
   align-items: center;
   padding: 5px 0 55px 0;
   background-color: #ffffff;
-  box-shadow: rgba(50, 50, 93, 0.25) 0px 6px 12px -2px,
+  box-shadow:
+    rgba(50, 50, 93, 0.25) 0px 6px 12px -2px,
     rgba(0, 0, 0, 0.3) 0px 3px 7px -3px;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease;
 
   &:hover {
     transform: scale(1.05);
-    box-shadow: rgba(17, 17, 26, 0.1) 0px 4px 16px,
+    box-shadow:
+      rgba(17, 17, 26, 0.1) 0px 4px 16px,
       rgba(17, 17, 26, 0.05) 0px 8px 32px;
   }
 }
@@ -26,9 +30,9 @@ $price-content-font-color: map-get($colors, dark-gray);
 .offer-card__header {
   text-transform: uppercase;
   width: 100%;
-  height: 2.5rem;
+  height: 3rem;
   position: relative;
-  font-size: 1.2rem;
+  font-size: 1.4rem;
   font-weight: 300;
 
   &::after {
@@ -46,7 +50,7 @@ $price-content-font-color: map-get($colors, dark-gray);
 .offer-card__content {
   color: $content-font-color;
   width: 70%;
-  font-size: 0.9rem;
+  font-size: 1.1rem;
   font-weight: 300;
 }
 
@@ -55,26 +59,26 @@ $price-content-font-color: map-get($colors, dark-gray);
 }
 
 .offer-card__price-content {
-  font-size: 0.95rem;
+  font-size: 1rem;
   font-weight: 500;
   margin: 5px;
   color: $price-content-font-color;
 }
 
-@media screen and (max-width: 1120px) and (min-width: 930px) {
+@media screen and (max-width: 1150px) and (min-width: 960px) {
   .offer-card {
-    width: 250px;
+    width: 280px;
   }
 
   .offer-card__header {
-    height: 2.2rem;
-    font-size: 1.1rem;
+    height: 2.5rem;
+    font-size: 1.2rem;
     font-weight: 300;
   }
 
   .offer-card__content {
     width: 70%;
-    font-size: 0.8rem;
+    font-size: 1rem;
     font-weight: 300;
   }
 
@@ -83,13 +87,13 @@ $price-content-font-color: map-get($colors, dark-gray);
   }
 
   .offer-card__price-content {
-    font-size: 0.8rem;
+    font-size: 1rem;
     font-weight: 500;
     margin: 5px;
   }
 }
 
-@media screen and (max-width: 930px) {
+@media screen and (max-width: 960px) {
   .offer-card {
     width: 70%;
     display: flex;
@@ -98,13 +102,17 @@ $price-content-font-color: map-get($colors, dark-gray);
     align-items: center;
     padding: 5px 0 55px 0;
     background-color: #ffffff;
-    box-shadow: rgba(50, 50, 93, 0.25) 0px 6px 12px -2px,
+    box-shadow:
+      rgba(50, 50, 93, 0.25) 0px 6px 12px -2px,
       rgba(0, 0, 0, 0.3) 0px 3px 7px -3px;
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    transition:
+      transform 0.2s ease,
+      box-shadow 0.2s ease;
 
     &:hover {
       transform: scale(1.05);
-      box-shadow: rgba(17, 17, 26, 0.1) 0px 4px 16px,
+      box-shadow:
+        rgba(17, 17, 26, 0.1) 0px 4px 16px,
         rgba(17, 17, 26, 0.05) 0px 8px 32px;
     }
   }

--- a/src/components/shared/shapes/HollowCircle.tsx
+++ b/src/components/shared/shapes/HollowCircle.tsx
@@ -1,0 +1,47 @@
+import { FC } from 'react'
+
+interface Props {
+  cx: number
+  cy: number
+  className?: string
+  radius: number
+  strokeWidth: number
+  color: string
+  svgSize: number
+  opacity?: number
+}
+
+const HollowCircle: FC<Props> = ({
+  cx,
+  cy,
+  className,
+  radius,
+  strokeWidth,
+  color,
+  svgSize,
+  opacity,
+}) => {
+  return (
+    <svg
+      className={`${className}`}
+      xmlns="http://www.w3.org/2000/svg"
+      version="1.1"
+      width={`${svgSize}`}
+      height={`${svgSize}`}
+      role="img"
+    >
+      <title>Hollow circle image decoration</title>
+      <circle
+        cx={`${cx}`}
+        cy={`${cy}`}
+        r={`${radius}`}
+        stroke={color}
+        strokeWidth={`${strokeWidth}`}
+        fill="none"
+        opacity={`${opacity}`}
+      />
+    </svg>
+  )
+}
+
+export default HollowCircle

--- a/src/styles/helpers/_variables.scss
+++ b/src/styles/helpers/_variables.scss
@@ -2,7 +2,8 @@
 
 $colors: (
   'white': #e2e2e2,
-  'background-blue': #73cdc0,
+  'background-blue': #13937f,
+  'header-blue': #23a491,
   'light-gray': #5a5a5a,
   'dark-gray': #413b3b,
 );


### PR DESCRIPTION
1. Zmiana kontrastu kolorów pomiędzy tłem a treścią aby [zapewnić czytelność](https://developer.mozilla.org/en-US/docs/Web/Accessibility/Understanding_WCAG/Perceivable/Color_contrast?utm_source=devtools&utm_medium=a11y-panel-checks-color-contrast#related_wcag_success_criteria)
2.  [Podpisanie elementów graficznych](https://developer.mozilla.org/en-US/docs/Web/Accessibility/Understanding_WCAG/Text_labels_and_names?utm_source=devtools&utm_medium=a11y-panel-checks-text-label#content_with_images_must_be_labeled) (hollow circles) - [Accesible SVG patterns](https://www.smashingmagazine.com/2021/05/accessible-svg-patterns-comparison/)
3. [Klikalne elementy](https://developer.mozilla.org/en-US/docs/Web/Accessibility/Understanding_WCAG/Keyboard?utm_source=devtools&utm_medium=a11y-panel-checks-keyboard#clickable_elements_must_be_focusable_and_should_have_interactive_semantics) - pojawiający się [problem w root](https://github.com/facebook/react/issues/20895)
4. Zmiana i refactor elementów graficznych (hollow circles) - SVG z `ellipse` na `circle` w celu braku wypełnienia w środku kółka przy ciemnym ekranie
5. Powiększenie czcionki w sekcji Oferta